### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,5 +5,5 @@ install:
   - # Prevent default install action "go get -t -v ./...".
 script:
   - go get -t -v ./...
-  - go tool vet .
+  - go vet .
   - go test -v -race ./...


### PR DESCRIPTION
Get rid of warning message:
```
$ go tool vet .
vet: invoking "go tool vet" directly is unsupported; use "go vet"
The command "go tool vet ." exited with 1.
```
https://travis-ci.org/go-toolsmith/astfmt/builds/603573990#L222